### PR TITLE
Fix make upgrade job

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,7 +10,3 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# diff-cover latest requires (pluggy>=0.13.1,<0.14.0)
-# which conflicts with pytest(pluggy>=0.12,<2.0.0) and tox(pluggy>0.12) both of these fetch pluggy==1.0.0
-diff-cover<6.2.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,11 +11,6 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-
-
-# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
-importlib-metadata==1.7.0
-
 # diff-cover latest requires (pluggy>=0.13.1,<0.14.0)
 # which conflicts with pytest(pluggy>=0.12,<2.0.0) and tox(pluggy>0.12) both of these fetch pluggy==1.0.0
 diff-cover<6.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,10 +51,8 @@ coverage[toml]==6.2
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-diff-cover==6.2.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev.in
+diff-cover==6.4.4
+    # via -r requirements/dev.in
 distlib==0.3.4
     # via
     #   -r requirements/ci.txt
@@ -77,8 +75,6 @@ idna==3.3
     # via
     #   -r requirements/ci.txt
     #   requests
-inflect==5.3.0
-    # via jinja2-pluralize
 iniconfig==1.1.1
     # via
     #   -r requirements/quality.txt
@@ -92,9 +88,6 @@ jinja2==3.0.3
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-    #   jinja2-pluralize
-jinja2-pluralize==0.3.0
-    # via diff-cover
 lazy-object-proxy==1.7.1
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -44,6 +44,8 @@ idna==3.3
     # via requests
 imagesize==1.3.0
     # via sphinx
+importlib-metadata==4.10.1
+    # via sphinx
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -103,7 +105,7 @@ six==1.16.0
     #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.3.2
+sphinx==4.4.0
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -137,6 +139,5 @@ urllib3==1.26.8
     # via requests
 webencodings==0.5.1
     # via bleach
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+zipp==3.7.0
+    # via importlib-metadata


### PR DESCRIPTION
### Description
- New version of `Sphinx` requires latest version of `importlib-metadata` which was pinned in the requirements and caused the `make upgrade` job to fail. Removed the unnecessary constraints and fixed the failing `make upgrade` job to run successfully.