### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade --verbose --rebuild -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade --verbose --rebuild -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade --verbose --rebuild -o requirements/test.txt requirements/test.in
 	pip-compile --upgrade --verbose --rebuild -o requirements/doc.txt requirements/doc.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -149,7 +149,7 @@ pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.12.0
     # via diff-cover
-pylint==2.14.0
+pylint==2.14.1
     # via
     #   -r requirements/quality.txt
     #   edx-lint

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -73,7 +73,7 @@ pycodestyle==2.8.0
     # via -r requirements/quality.in
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pylint==2.14.0
+pylint==2.14.1
     # via
     #   edx-lint
     #   pylint-celery


### PR DESCRIPTION
**Description:**
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 

JIRA: https://2u-internal.atlassian.net/browse/BOM-3446