### PR TITLE
fix: remove codecov package requirement

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
-pytz==2022.7.1
+pytz==2023.3
     # via django
 sqlparse==0.4.3
     # via django

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,32 +4,20 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.2
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,29 +8,17 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.0
+astroid==2.15.3
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   pytest
 build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2022.12.7
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==3.1.0
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
@@ -47,13 +35,9 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 diff-cover==7.5.0
     # via -r requirements/dev.in
@@ -78,15 +62,11 @@ exceptiongroup==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-idna==3.4
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
@@ -112,7 +92,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -126,9 +106,9 @@ pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -151,9 +131,9 @@ pycodestyle==2.10.0
     # via -r requirements/quality.txt
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.14.0
+pygments==2.15.0
     # via diff-cover
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -177,7 +157,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -190,7 +170,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   django
@@ -199,10 +179,6 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
-requests==2.28.2
-    # via
-    #   -r requirements/ci.txt
-    #   codecov
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -236,7 +212,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -252,10 +228,6 @@ typing-extensions==4.5.0
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.15
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 virtualenv==20.21.0
     # via
     #   -r requirements/ci.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,10 +10,6 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 babel==2.12.1
     # via sphinx
 bleach==6.0.0
@@ -22,7 +18,7 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -48,7 +44,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.1.0
+importlib-metadata==6.4.1
     # via sphinx
 iniconfig==2.0.0
     # via
@@ -58,7 +54,7 @@ jinja2==3.1.2
     # via sphinx
 markupsafe==2.1.2
     # via jinja2
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -69,12 +65,12 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   doc8
     #   readme-renderer
     #   sphinx
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -83,7 +79,7 @@ pytest-cov==4.0.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   babel

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,14 +8,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.3
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 click==8.1.3
     # via
     #   click-log
@@ -25,7 +21,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -57,13 +53,13 @@ markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via pylint
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
 pbr==5.11.1
     # via stevedore
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -73,7 +69,7 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -87,7 +83,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -98,7 +94,7 @@ pytest-django==4.5.2
     # via -r requirements/test.txt
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   django
@@ -122,7 +118,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,9 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-attrs==22.2.0
-    # via pytest
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -19,11 +17,11 @@ exceptiongroup==1.1.1
     # via pytest
 iniconfig==2.0.0
     # via pytest
-packaging==23.0
+packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -31,7 +29,7 @@ pytest-cov==4.0.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   django


### PR DESCRIPTION
### Description
- Codecov deprecated the pypi package long ago (Feb 2022) but left it up until now.
- Removing the package from requirements to fix the failing upgrade job.
- The Github Action we use to upload to codecov doesn’t depend on the package so our CI coverage won’t be affected by the change