### PR TITLE
docs: Update edx.rtd links to docs.openedx.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Overview
 This repo houses utility functions to protect edx codebase (Python, Javascript and other templating
 engine eg django/mako) against possible XSS attacks. Helper code include html & js escaping filters
 for django and mako templates.
-For more information, please read `Preventing Cross Site Scripting Vulnerabilities <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/index.html>`_.
+For more information, please read `Preventing Cross Site Scripting Vulnerabilities <https://docs.openedx.org/en/latest/developers/references/developer_guide/preventing_xss/index.html>`_.
 
 Documentation
 -------------


### PR DESCRIPTION
We've moved docs to docs.openedx.org so update the URLs.